### PR TITLE
ts: Stronger signal and query type definitions

### DIFF
--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -47,7 +47,7 @@ export interface WorkflowSignalWithStartOptionsWithoutArgs<SignalArgs extends an
   /**
    * SignalDefinition or name of signal
    */
-  signal: SignalDefinition | string;
+  signal: SignalDefinition<SignalArgs> | string;
 
   /**
    * Arguments to invoke the signal handler with

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -15,26 +15,31 @@ export type WorkflowQueryType = (...args: any[]) => any;
  */
 export type Workflow = (...args: any[]) => WorkflowReturnType;
 
+declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
  * @remarks `_Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface SignalDefinition<_Args extends any[] = []> {
+export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
   type: 'signal';
-  name: string;
+  name: Name;
+  [argsBrand]: Args;
 }
 
+declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
  * @remarks `_Args` and `_Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface QueryDefinition<_Ret, _Args extends any[] = []> {
+export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {
   type: 'query';
-  name: string;
+  name: Name;
+  [argsBrand]: Args;
+  [retBrand]: Ret;
 }
 
 /** Get the "unwrapped" return type (without Promise) of the execute handler from Workflow type `W` */

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -19,7 +19,7 @@ declare const argsBrand: unique symbol;
 /**
  * An interface representing a Workflow signal definition, as returned from {@link defineSignal}
  *
- * @remarks `_Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface SignalDefinition<Args extends any[] = [], Name extends string = string> {
@@ -32,7 +32,7 @@ declare const retBrand: unique symbol;
 /**
  * An interface representing a Workflow query definition as returned from {@link defineQuery}
  *
- * @remarks `_Args` and `_Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
+ * @remarks `Args` and `Ret` can be used for parameter type inference in handler functions and *WorkflowHandle methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface QueryDefinition<Ret, Args extends any[] = [], Name extends string = string> {

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -21,7 +21,7 @@ export interface BaseWorkflowHandle<T extends Workflow> {
    * await handle.signal(incrementSignal, 3);
    * ```
    */
-  signal<Args extends any[] = []>(def: SignalDefinition<Args> | string, ...args: Args): Promise<void>;
+  signal<Args extends any[] = [], Name extends string = string>(def: SignalDefinition<Args, Name> | string, ...args: Args): Promise<void>;
 
   /**
    * The workflowId of the current Workflow

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -1122,11 +1122,11 @@ function conditionInner(fn: () => boolean): Promise<void> {
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to signal Workflows using a {@link WorkflowHandle}, {@link ChildWorkflowHandle} or {@link ExternalWorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineSignal<Args extends any[] = []>(name: string): SignalDefinition<Args> {
+export function defineSignal<Args extends any[] = [], Name extends string = string>(name: Name): SignalDefinition<Args, Name> {
   return {
     type: 'signal',
     name,
-  };
+  } as SignalDefinition<Args, Name>;
 }
 
 /**
@@ -1135,11 +1135,11 @@ export function defineSignal<Args extends any[] = []>(name: string): SignalDefin
  * Definitions are used to register handler in the Workflow via {@link setHandler} and to query Workflows using a {@link WorkflowHandle}.
  * Definitions can be reused in multiple Workflows.
  */
-export function defineQuery<Ret, Args extends any[] = []>(name: string): QueryDefinition<Ret, Args> {
+export function defineQuery<Ret, Args extends any[] = [], Name extends string =  string>(name: string): QueryDefinition<Ret, Args, Name> {
   return {
     type: 'query',
     name,
-  };
+  } as QueryDefinition<Ret, Args, Name>;
 }
 
 /**


### PR DESCRIPTION
## What was changed

This PR makes two refinements to the `SignalDefinition` and `QueryDefinition` types:
1. `Args` and `Ret` types are branded into the resulting types, using virtual symbolic brands. This addresses #1051
2. The `name` field is allowed to be narrowed to sub-type of `string` via an optional generic which defaults to `string`. I've used the least-intrusive option available here, which leaves behavior completely unchanged for existing callers, at the expense of making strict names a bit more verbose. This addresses #1052 

## Why?

Because #1051 and #1052 are making me sad.

## Checklist

1. Closes #1051 and #1052
2. How was this tested:  
    - [x] `npm run test`
    - [ ] Integration tests
    - [ ] `test-npm-init`
3. Any docs updates needed? **Probably**